### PR TITLE
Fix / Removed role requirement in user registration

### DIFF
--- a/api/Controllers/AuthController.cs
+++ b/api/Controllers/AuthController.cs
@@ -43,7 +43,7 @@ namespace api.Controllers
         /// <summary>
         /// Endpoint for user registration
         /// </summary>
-        /// <param name="userDto">User data including username, email, password, role and birthday</param>
+        /// <param name="userDto">User data including username, email, password and birthday</param>
         /// <returns>Success response with user ID or error messages</returns>
         [HttpPost("Register")]
         public async Task<ActionResult> Register(UserDto userDto)
@@ -88,7 +88,6 @@ namespace api.Controllers
                 {
                     UserName = userDto.userName,
                     Email = userDto.email,
-                    Role = userDto.role,
                     Birthday = userDto.birthday,
                     RegistrationDate = DateTime.Now
                 };
@@ -164,7 +163,6 @@ namespace api.Controllers
                 id = user.Id,
                 userName = user.UserName!,
                 email = user.Email!,
-                role = user.Role,
                 token = _utils.GenerateJWT(user)
             };
 

--- a/api/Controllers/UserController.cs
+++ b/api/Controllers/UserController.cs
@@ -218,7 +218,6 @@ namespace api.Controllers
 
             // Update user properties
             userModel.UserName = userDto.userName;
-            userModel.Role = userDto.role;
             userModel.Email = userDto.email;
             userModel.Birthday = userDto.birthday;
 

--- a/api/Data/ApplicationDBContext.cs
+++ b/api/Data/ApplicationDBContext.cs
@@ -10,7 +10,6 @@ namespace api.Data
     public class ApplicationDBContext : IdentityDbContext<User, IdentityRole<int>, int>
     {
         public ApplicationDBContext(DbContextOptions<ApplicationDBContext> options) : base(options) { }
-
         public DbSet<UserTask> UserTasks { get; set; }
         public DbSet<Activity> Activities { get; set; }
         public DbSet<Course> Courses { get; set; }

--- a/api/Dtos/User/CreateUserRequestDto.cs
+++ b/api/Dtos/User/CreateUserRequestDto.cs
@@ -8,10 +8,7 @@ namespace api.Dtos.User
         
         // Required password (should be hashed before storage)
         public string password { get; set; }
-        
-        // User role (e.g., "Admin", "User")
-        public string role { get; set; }
-        
+    
         // Required unique email
         public string email { get; set; }
         

--- a/api/Dtos/User/UpdateUserRequestDto.cs
+++ b/api/Dtos/User/UpdateUserRequestDto.cs
@@ -9,9 +9,6 @@ namespace api.Dtos.User
         // New password (should be hashed before storage)
         public string password { get; set; }
 
-        // Updated user role/permissions
-        public string role { get; set; }
-
         // Updated email (must remain unique)
         public string email { get; set; }
 

--- a/api/Dtos/User/UserDto.cs
+++ b/api/Dtos/User/UserDto.cs
@@ -16,9 +16,6 @@ namespace api.Dtos.User
         [StringLength(100, MinimumLength = 6, ErrorMessage = "La contraseña debe tener al menos 6 caracteres")]
         public string password { get; set; }
         
-        [Required(ErrorMessage = "El rol es requerido")]
-        public string role { get; set; }
-        
         [Required(ErrorMessage = "El email es requerido")]
         [EmailAddress(ErrorMessage = "El formato del email no es válido")]
         public string email { get; set; }

--- a/api/Mappers/UserMapper.cs
+++ b/api/Mappers/UserMapper.cs
@@ -14,7 +14,6 @@ namespace api.Mappers
             {
                 id = userModel.Id,
                 userName = userModel.UserName!,
-                role = userModel.Role,
                 email = userModel.Email!,
                 birthday = userModel.Birthday,
                 registrationDate = userModel.RegistrationDate
@@ -28,7 +27,6 @@ namespace api.Mappers
             return new User
             {
                 UserName = userDto.userName,
-                Role = userDto.role,
                 Email = userDto.email,
                 Birthday = userDto.birthday,
                 RegistrationDate = DateTime.Now

--- a/api/Models/User.cs
+++ b/api/Models/User.cs
@@ -1,17 +1,13 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Identity;
 
-// Main user entity model
 // Main user entity model
 namespace api.Models
 {
     // Custom ApplicationUser extending IdentityUser
     public class User : IdentityUser<int>
     {
-
-        public string Role { get; set; }              // Optional: role info (can also use IdentityRole)
         public DateTime Birthday { get; set; }        // Custom field
         public DateTime RegistrationDate { get; set; } // Custom field
         

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -10,8 +10,6 @@ using api.Services;
 using api.Custome;
 using Microsoft.OpenApi.Models;
 using Microsoft.Extensions.FileProviders;
-using System.Collections.Generic;
-using System.IO;  
 
 var builder = WebApplication.CreateBuilder(args);
 


### PR DESCRIPTION
Adjusted the registration logic to no longer require the "role" field from the user during account creation.

Changes made:
- Modified `RegisterRequest` DTO to remove the `role` property.
- Updated registration logic in `AuthService` to assign a default role internally (if necessary).
- Cleaned up the controller and viewmodel references to reflect the updated model.

Acceptance criteria:
✓ User can register without having to provide a role manually.  
✓ Existing logic works as expected for valid registrations.  
✓ No other parts of the app are affected by this change.

Test cases:
1. Name: Register without role  
   Steps:
   - Send name, email, password, and birthdate to the endpoint (no role)  
   - Observe success response  
   Expected: User is registered successfully  

2. Name: Compatibility test  
   Steps:
   - Ensure existing login and token logic still works after registering  
   Expected: Token is generated correctly and user is authenticated  